### PR TITLE
Pr9 py2k future import

### DIFF
--- a/ropemode/__init__.py
+++ b/ropemode/__init__.py
@@ -1,7 +1,7 @@
 """ropemode, a helper for using rope refactoring library in IDEs"""
 
 INFO = __doc__
-VERSION = '0.2'
+VERSION = '0.3a1'
 COPYRIGHT = """\
 Copyright (C) 2007-2012 Ali Gholami Rudi
 

--- a/ropemode/decorators.py
+++ b/ropemode/decorators.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from future.builtins import str
+
 import traceback
 
 from rope.base import exceptions
@@ -16,7 +19,7 @@ class Logger(object):
 
     def _show(self, message):
         if message is None:
-            print message
+            print(message)
         else:
             self.message(message)
 
@@ -27,7 +30,7 @@ def lisphook(func):
     def newfunc(*args, **kwds):
         try:
             func(*args, **kwds)
-        except Exception, e:
+        except Exception as e:
             trace = str(traceback.format_exc())
             short = 'Ignored an exception in ropemode hook: %s' % \
                     _exception_message(e)
@@ -51,7 +54,7 @@ def _exception_handler(func, raise_exceptions, error_return):
     def newfunc(*args, **kwds):
         try:
             return func(*args, **kwds)
-        except exceptions.RopeError, e:
+        except exceptions.RopeError as e:
             short = None
             if isinstance(e, input_exceptions):
                 if not raise_exceptions:

--- a/ropemode/filter.py
+++ b/ropemode/filter.py
@@ -23,7 +23,7 @@ def resources(project, rules):
         except exceptions.ResourceNotFoundError:
             continue
         if resource.is_folder():
-            matches = set(filter(lambda item: resource.contains(item), all))
+            matches = set([item for item in all if resource.contains(item)])
         else:
             matches = set([resource])
         if first == '+':

--- a/ropemode/interface.py
+++ b/ropemode/interface.py
@@ -1,3 +1,5 @@
+from future.builtins import dict, map, range, str, zip
+
 import os
 
 import rope.base.change
@@ -300,7 +302,7 @@ class RopeMode(object):
         if modules:
             for i in range(len(modules)):
                 modname = modules[i]
-                if not isinstance(modname, basestring):
+                if not isinstance(modname, str):
                     modname = modname.value()
                 modnames.append(modname)
         else:
@@ -582,7 +584,7 @@ class _CodeAssist(object):
             self._starting = common_start
             self._offset = self.starting_offset + len(common_start)
         prompt = 'Completion for %s: ' % self.expression
-        proposals = map(self.env._completion_data, proposals)
+        proposals = list(map(self.env._completion_data, proposals))
         result = self.env.ask_completion(prompt, proposals, self.starting)
         if result is not None:
             self._apply_assist(result)

--- a/ropemode/refactor.py
+++ b/ropemode/refactor.py
@@ -1,3 +1,5 @@
+from future.builtins import str
+
 import re
 
 import rope.base.change

--- a/ropemodetest.py
+++ b/ropemodetest.py
@@ -1,3 +1,4 @@
+from future.builtins import super
 import unittest
 
 from ropemode import dialog

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,3 @@ setup(name='ropemode',
       requires=['rope (>= 0.9.4)'],
       **extra_kwargs
 )
-

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,17 @@
+import sys
+
+if sys.version < '3':
+    rope_package = 'rope'
+else:
+    rope_package = 'rope_py3k'
+
 extra_kwargs = {}
 try:
     from setuptools import setup
-    extra_kwargs['install_requires'] = ['rope >= 0.9.4']
+    extra_kwargs['install_requires'] = [
+        'future >= 0.11.2',
+        rope_package + ' >= 0.9.4'
+    ]
 except ImportError:
     from distutils.core import setup
 
@@ -29,6 +39,6 @@ setup(name='ropemode',
       packages=['ropemode'],
       license='GNU GPL',
       classifiers=classifiers,
-      requires=['rope (>= 0.9.4)'],
+      requires=['future (>= 0.11.2)', rope_package + ' (>= 0.9.4)'],
       **extra_kwargs
 )


### PR DESCRIPTION
Originally from https://bitbucket.org/agr/ropemode/pull-request/9

@pmcnr, any more comments on this?

Adding comments from Bitbucket:
By @jagguli
Debugger entered--Lisp error: (error "Python: Traceback (most recent call last): File \"/home/steven/.local/lib/python3.3/site-packages/Pymacs.py\", line 201, in loop value = eval(text) File \"<string>\", line 1, in <module> File \"/home/steven/.local/lib/python3.3/site-packages/Pymacs.py\", line 429, in pymacs_load_helper module = import(module_name) File \"/home/steven/.local/lib/python3.3/site-packages/ropemacs-0.8a1-py3.3.egg/ropemacs/init.py\", line 6, in <module> File \"./ropemode/decorators.py\", line 6, in <module> from rope.base import exceptions ImportError: No module named 'rope' ") sig

By @pmcnr
The following is working for me:

```
$ pip3.3 install --user --upgrade https://bitbucket.org/pmcnr/ropemode/branch/default
$ pip3.3 install --user --upgrade https://bitbucket.org/pmcnr/ropemacs/branch/default
```

I would just note that we really don’t reasonable support for py3k (its analysis), see discussion at https://github.com/python-rope/rope/issues/57
