### PR TITLE
add rope project autodiscovery

### DIFF
--- a/ropemode/interface.py
+++ b/ropemode/interface.py
@@ -79,17 +79,17 @@ class RopeMode(object):
             self.close_project()
 
     def _find_project(self):
-        root = os.curdir
+        root = os.path.abspath(os.path.dirname(self.env.filename()))
 
         # TODO: allow to configure the search depth
         for _ in range(2):
             root = os.path.join(root, os.pardir)
 
-        for root, dirs, files in os.walk(top=os.pardir, topdown=False):
+        for curdir, dirs, files in os.walk(top=root, topdown=False):
             if [f for f in files if f.endswith('.py')]:
                 for folder in dirs:
                     if folder == '.ropeproject':
-                        return os.path.abspath(root)
+                        return os.path.abspath(curdir)
         else:
             return None
 


### PR DESCRIPTION
This is a small improvement I use in my ropemode.

I use Rope with Emacs and I usually have several python projects opened at the same time. Every time I switch to a different project or I open a new one I get prompted to the ropeproject location request which is quite irritating.

Such simple code allows Rope Mode to try to discovery the location before asking it to the user. The algorithm is pretty simple: it traverse the project folders from the bottom to up to two folders from the one in which we are working.

I'd like to make such feature configurable so that the user can both decide whether to enable it or not and how many folders upward to look into but I'm not familiar with the whole thing. If you have any suggestion I'd be glad to improve the code snippet.

Something to add in my emacs.d like:
(ropemode project-folder-autodiscovery t)
(ropemode autodiscovery-depth 2)
