### PR TITLE
don't use `basestring`; it doesn't exist on py3

### DIFF
--- a/ropemode/interface.py
+++ b/ropemode/interface.py
@@ -300,7 +300,7 @@ class RopeMode(object):
         if modules:
             for i in range(len(modules)):
                 modname = modules[i]
-                if not isinstance(modname, basestring):
+                if not isinstance(modname, str):
                     modname = modname.value()
                 modnames.append(modname)
         else:


### PR DESCRIPTION
Module names must always be `str` regardless of python version, so presumably that's what should be reflected here.