### PR TITLE
Destination module option to GenerateClass Refactoring

### DIFF
--- a/generatetest.py
+++ b/generatetest.py
@@ -1,0 +1,97 @@
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+from rope.base import libutils
+from rope.base.project import Project
+
+from ropemode.environment import Environment
+from ropemode.interface import RopeMode
+from ropemode.refactor import GenerateClass
+
+
+class ResourceMock:
+    real_path = "/tmp/other.py"
+    path = "other.py"
+
+
+class GenerateTest(unittest.TestCase):
+    def setUp(self):
+        self.env = self._get_environment_mock()
+        self.interface = RopeMode(self.env)
+
+        self._mock_rope_project()
+        self._mock_rope_create_generate_method()
+        self._mock_libutils_path_to_resource()
+
+    def tearDown(self):
+        self._cg_patcher.stop()
+        self._libutils_patcher.stop()
+
+    def test_generate_class_asks_for_destination_module(self):
+        self._given_menu_options_will_be_selected(["cancel"])
+
+        generate = GenerateClass(self.interface, self.env)
+        generate.show()
+
+        asked_values = self._get_asked_values()
+        self.assertIn("destination module", asked_values)
+
+    def test_generate_class_perform_refactoring_with_specified_module(self):
+        self._given_menu_options_will_be_selected(["destination module", "perform"])
+        self._given_value_answered("other.py")
+
+        generate = GenerateClass(self.interface, self.env)
+        generate.show()
+
+        self.assertEqual(self.create_generate.call_count, 2)
+        self.assertEqual(
+            self._create_generate_called_with("goal_resource").path, "other.py"
+        )
+
+    def _mock_rope_project(self):
+        self.interface.open_project = Mock()
+        self.interface.project = MagicMock()
+        self.interface.project.get_resource.return_value = ResourceMock
+
+    def _mock_rope_create_generate_method(self):
+        self._cg_patcher = patch("rope.contrib.generate.create_generate")
+        self.create_generate = self._cg_patcher.start()
+
+        generator = MagicMock()
+        generator.get_location.return_value = Mock(), 0
+        self.create_generate.return_value = generator
+
+    def _mock_libutils_path_to_resource(self):
+        self._libutils_patcher = patch.object(libutils, "path_to_resource")
+        self._libutils_patcher.start()
+
+    def _get_asked_values(self):
+        asked_values = self.env.get_called_kwargs_list(self.env.ask_values)["values"]
+        return asked_values
+
+    def _given_menu_options_will_be_selected(self, options):
+        self.env.ask_values = MagicMock(side_effect=options)
+
+    def _given_value_answered(self, value):
+        self.env.ask = MagicMock()
+        self.env.ask.return_value = value
+
+    def _get_environment_mock(self):
+        env = Environment()
+        env.ask_directory = MagicMock(return_value="/tmp/")
+        env.y_or_n = MagicMock(return_value=True)
+        env.create_progress = MagicMock(return_value=Mock())
+        env.filenames = MagicMock(
+            return_value=[
+                "test.py",
+            ]
+        )
+        env.get_called_kwargs_list = lambda x: list(x.call_args)[1]
+        return env
+
+    def _create_generate_called_with(self, key):
+        return self.create_generate.call_args[1][key]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ropemode/refactor.py
+++ b/ropemode/refactor.py
@@ -12,6 +12,7 @@ import rope.refactor.rename
 import rope.refactor.restructure
 import rope.refactor.usefunction
 from rope.base import taskhandle
+import rope.base.exceptions
 
 from ropemode import dialog, filter
 
@@ -439,25 +440,36 @@ class GenerateFunction(_GenerateElement):
 
 class GenerateClass(_GenerateElement):
     key = 'n c'
-    optionals = {"destination module": dialog.Data(
-                     prompt="Destination module: ")}
+
+    def _get_optionals(self):
+        return {"destination module": dialog.Data(
+                    prompt="Destination module: "
+    )}
 
     def _calculate_changes(self, values, task_handle):
-        kind = self.name.split("_")[-1]
+        self.generator = rope.contrib.generate.create_generate(
+            self._get_kind(), self.project, self.resource,
+            self.offset, goal_resource=self._get_goal_resource(values))
+        return self.generator.get_changes()
 
-        if "destination module" in values and values["destination module"]:
-            goal_resource = self.project.get_resource(values["destination module"])
-        else:
-            goal_resource = None
-        generator = rope.contrib.generate.create_generate(
-            kind,
-            self.project,
-            self.resource,
-            self.offset,
-            goal_resource=goal_resource,
-        )
+    def _get_kind(self):
+        kind = self.name.split('_')[-1]
+        return kind
 
-        return generator.get_changes()
+    def _get_goal_resource(self, values):
+        goal_resource = None
+        if self._has_destination_module(values):
+            goal_resource = self._get_destination_resource_or_raise_error(values, goal_resource)
+        return goal_resource
+
+    def _has_destination_module(self, values):
+        return "destination module" in values and values["destination module"]
+
+    def _get_destination_resource_or_raise_error(self, values, goal_resource):
+        goal_resource = self.project.find_module(values["destination module"])
+        if not goal_resource:
+            raise rope.base.exceptions.RefactoringError("Module not found")
+        return goal_resource
 
 
 class GenerateModule(_GenerateElement):

--- a/ropemode/refactor.py
+++ b/ropemode/refactor.py
@@ -439,6 +439,25 @@ class GenerateFunction(_GenerateElement):
 
 class GenerateClass(_GenerateElement):
     key = 'n c'
+    optionals = {"destination module": dialog.Data(
+                     prompt="Destination module: ")}
+
+    def _calculate_changes(self, values, task_handle):
+        kind = self.name.split("_")[-1]
+
+        if "destination module" in values and values["destination module"]:
+            goal_resource = self.project.get_resource(values["destination module"])
+        else:
+            goal_resource = None
+        generator = rope.contrib.generate.create_generate(
+            kind,
+            self.project,
+            self.resource,
+            self.offset,
+            goal_resource=goal_resource,
+        )
+
+        return generator.get_changes()
 
 
 class GenerateModule(_GenerateElement):


### PR DESCRIPTION
Added option in GenerateClass to set destination module. You can generate class in a different file than currently editing.

https://www.youtube.com/watch?v=VNol1Q7ErPc

Change in Rope is needed: https://github.com/python-rope/rope/pull/332

